### PR TITLE
Fix under quarter-line handling for Under totals

### DIFF
--- a/daily_/daily_brief
+++ b/daily_/daily_brief
@@ -141,10 +141,10 @@ def ou_ev_kelly_from_totals_quarter(line: float, over_odds: float, under_odds: f
             fl = 1.0 - fw
             return fw, 0.0, 0.0, 0.0, fl
         elif frac == 0.25:
-            fw = sum(t <= a for t in totals_list) / n
+            fw = sum(t < a for t in totals_list) / n
             hw = sum(t == a for t in totals_list) / n
             fl = sum(t >= a + 1 for t in totals_list) / n
-            remain = 1.0 - fw - hw - fl
+            remain = max(0.0, 1.0 - fw - hw - fl)
             return fw, hw, remain, 0.0, fl
         elif frac == 0.75:
             fw = sum(t <= a for t in totals_list) / n
@@ -174,6 +174,16 @@ def ou_ev_kelly_from_totals_quarter(line: float, over_odds: float, under_odds: f
 
     return {"EV_over": float(EV_over), "Kelly_over": float(K_over),
             "EV_under": float(EV_under), "Kelly_under": float(K_under)}
+
+def _regression_check_quarter_under() -> None:
+    """Verify under-quarter lines treat integer totals as half wins."""
+    totals = [1, 2, 3, 4]
+    res = ou_ev_kelly_from_totals_quarter(2.25, 2.0, 2.0, totals)
+    expected_ev_under = -0.125
+    if not math.isclose(res["EV_under"], expected_ev_under, rel_tol=1e-12, abs_tol=1e-12):
+        raise AssertionError(
+            f"Quarter-line under regression failed: expected EV_under {expected_ev_under}, got {res['EV_under']}"
+        )
 
 # ================== 预取与缓存 ==================
 TEAM_STATS_CACHE: dict[tuple[int,int,int], dict] = {}
@@ -894,6 +904,8 @@ def main():
 
 if __name__ == "__main__":
     try:
+        if os.environ.get("DAILY_BRIEF_SELFTEST") == "1":
+            _regression_check_quarter_under()
         main()
     except Exception as e:
         print("程序异常：", e)


### PR DESCRIPTION
## Summary
- ensure under-quarter full-win probabilities only include totals strictly below the integer component
- clamp the remaining probability mass to zero to avoid negative push values
- add an optional regression guard for the quarter-line under scenario behind the DAILY_BRIEF_SELFTEST flag

## Testing
- not run (environment lacks required dependencies such as numpy)


------
https://chatgpt.com/codex/tasks/task_e_68c999ccb7088330ba144c8dadc6a787