### PR TITLE
Fix Kelly calculation and add tests

### DIFF
--- a/daily_/value_engine.py
+++ b/daily_/value_engine.py
@@ -99,10 +99,17 @@ def ev_kelly(p: float, odds: float, k_fraction: float=1.0):
         p = float(p); o = float(odds)
         if not (0<=p<=1) or o<=1: return None, None
         ev = p*o - 1
-        num = (p*o - (1-p)); den = (o - 1.0)
+        num = p*o - 1.0
+        den = (o - 1.0)
         f = num/den if den>0 else None
-        if f is None or f<=0: return round(ev,6), None
-        return round(ev,6), round(min(1.0, max(0.0, f*k_fraction)), 6)
+        if f is None:
+            return round(ev,6), None
+        if f <= 0:
+            return (round(ev,6), 0.0) if abs(f) <= 1e-9 else (round(ev,6), None)
+        f_adj = min(1.0, max(0.0, f*k_fraction))
+        if f_adj <= 0:
+            return round(ev,6), 0.0
+        return round(ev,6), round(f_adj, 6)
     except Exception:
         return None, None
 

--- a/tests/test_value_engine.py
+++ b/tests/test_value_engine.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "daily_"))
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.random = types.SimpleNamespace(seed=lambda _=None: None)
+numpy_stub.isscalar = lambda obj: isinstance(obj, (int, float, complex, bool))
+sys.modules.setdefault("numpy", numpy_stub)
+
+import value_engine  # noqa: E402
+
+
+def test_ev_kelly_returns_zero_for_fair_even_money_odds():
+    ev, kelly = value_engine.ev_kelly(0.5, 2.0)
+    assert ev == 0.0
+    assert kelly == 0.0
+
+
+def test_ev_kelly_positive_value_bet():
+    ev, kelly = value_engine.ev_kelly(0.55, 2.2)
+    assert ev == 0.21
+    assert kelly == 0.175
+
+
+def test_ev_kelly_negative_value_returns_none():
+    ev, kelly = value_engine.ev_kelly(0.4, 2.0)
+    assert ev == -0.2
+    assert kelly is None


### PR DESCRIPTION
## Summary
- restore the Kelly numerator to `p*o - 1` and ensure zero-stake outcomes return 0 instead of `None`
- add pytest coverage for `ev_kelly`, including the even-money case and a numpy stub for import isolation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a7df065c8330860fef22fc789931