### PR TITLE
Fix Kelly numerator to use EV

### DIFF
--- a/daily_/value_engine.py
+++ b/daily_/value_engine.py
@@ -99,7 +99,7 @@ def ev_kelly(p: float, odds: float, k_fraction: float=1.0):
         p = float(p); o = float(odds)
         if not (0<=p<=1) or o<=1: return None, None
         ev = p*o - 1
-        num = p*o - 1.0
+        num = ev
         den = (o - 1.0)
         f = num/den if den>0 else None
         if f is None:


### PR DESCRIPTION
## Summary
- reuse the computed expected value as the Kelly numerator to match the standard formula

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68c9aa9016a48330b6a4b77750987a8e