### PR TITLE
Normalize AH handicap keys for odds aggregation

### DIFF
--- a/daily_/daily_/football_api.py
+++ b/daily_/daily_/football_api.py
@@ -226,11 +226,23 @@ def odds_by_fixture(fixture_id: int) -> Dict[str, float]:
                         line = _parse_float(v.get("handicap"))
                         if side_txt not in ("home","away") or line is None or odd is None:
                             continue
-                        home_line = float(line) if side_txt == "home" else -float(line)
-                        if 1.10 <= odd <= 50.0:
-                            ah_map.setdefault(home_line, {"home": [], "away": []})
-                            if side_txt == "home": ah_map[home_line]["home"].append(odd)
-                            else:                  ah_map[home_line]["away"].append(odd)
+                        if not (1.10 <= odd <= 50.0):
+                            continue
+
+                        line_val = float(line)
+                        # Reuse existing keys so that Home/Away selections from the same
+                        # bookmaker line land in the same entry (处理正负盘符). This fixes
+                        # cases where one side was inserted first with the opposite sign.
+                        resolved_line: Optional[float] = None
+                        for cand in (line_val, -line_val):
+                            if cand in ah_map:
+                                resolved_line = cand
+                                break
+                        if resolved_line is None:
+                            resolved_line = line_val if side_txt == "home" else -line_val
+
+                        ah_map.setdefault(resolved_line, {"home": [], "away": []})
+                        ah_map[resolved_line][side_txt].append(odd)
 
     out: Dict[str, float] = {}
 


### PR DESCRIPTION
## Summary
- reuse an existing Asian handicap key when either side of a bookmaker line has already been recorded so home/away odds map to the same entry
- keep the canonical home-line sign for new entries after checking both the published and negated handicaps, ensuring aggregated maps include both sides

## Testing
- python -m compileall daily_/daily_/football_api.py


------
https://chatgpt.com/codex/tasks/task_e_68cac4bcda6c8330b74dc1bdfe82bed9