### PR TITLE
Preserve EV threshold diagnostics after merge

### DIFF
--- a/daily_/daily_brief
+++ b/daily_/daily_brief
@@ -149,7 +149,7 @@ def apply_ev_filter(
     flag_map: Dict[str, str],
     reason_map: Dict[str, str],
     vi_map: Dict[str, float | None],
-    meta_map: Dict[str, Dict[str, float | str]] | None = None,
+    meta_map: Dict[str, Dict[str, object]] | None = None,
     odds: float | None = None,
     model_prob: float | None = None,
     consensus_prob: float | None = None,
@@ -182,7 +182,8 @@ def apply_ev_filter(
         reason_map[key] = ",".join(str(r) for r in reasons)
     vi_map[key] = res.get("value_index")
     if meta_map is not None:
-        meta_entry: Dict[str, float | str] = {}
+        diagnostics = meta_map.setdefault("diagnostics", {})
+        meta_entry: Dict[str, object] = {}
         quality = res.get("quality")
         if quality is not None:
             try:
@@ -201,8 +202,11 @@ def apply_ev_filter(
                 meta_entry["ev_calibrated"] = round(float(ev_cal), 6)
             except (TypeError, ValueError):
                 pass
+        thresholds = res.get("thresholds")
+        if isinstance(thresholds, dict) and thresholds:
+            meta_entry["thresholds"] = thresholds
         if meta_entry:
-            meta_map[key] = meta_entry
+            diagnostics[key] = meta_entry
     return res.get("ev"), res.get("kelly")
 
 # ===== 四分之一盘精结算（基于 totals 样本）=====
@@ -1051,7 +1055,7 @@ def main():
         flag_map: Dict[str, str] = {}
         flag_reason_map: Dict[str, str] = {}
         vi_map: Dict[str, float | None] = {}
-        ev_meta_map: Dict[str, Dict[str, float | str]] = {}
+        ev_meta_map: Dict[str, Dict[str, object]] = {}
 
         # ===== 1X2 =====
         o1_h,o1_d,o1_a = odds.get("1x2_home"),odds.get("1x2_draw"),odds.get("1x2_away")
@@ -1659,7 +1663,15 @@ def main():
             row[f"flag_{key}"] = tag
         for key, reason in flag_reason_map.items():
             row[f"flag_reason_{key}"] = reason
-        for key, meta in ev_meta_map.items():
+        diagnostics_src = ev_meta_map.get("diagnostics")
+        if isinstance(diagnostics_src, dict):
+            diagnostics_items = diagnostics_src.items()
+        else:
+            diagnostics_items = ((k, v) for k, v in ev_meta_map.items() if k != "diagnostics")
+
+        for key, meta in diagnostics_items:
+            if not isinstance(meta, dict):
+                continue
             quality_f: float | None = None
             ev_input_f: float | None = None
             ev_cal_f: float | None = None
@@ -1684,6 +1696,26 @@ def main():
                     row[f"ev_calibrated_{key}"] = round(ev_cal_f, 6)
                 except (TypeError, ValueError):
                     ev_cal_f = None
+            thresholds = meta.get("thresholds")
+            if isinstance(thresholds, dict):
+                keep_min_val = thresholds.get("keep_min")
+                keep_max_val = thresholds.get("keep_max")
+                drop_val = thresholds.get("drop")
+                if keep_min_val is not None:
+                    try:
+                        row[f"threshold_keep_min_{key}"] = round(float(keep_min_val), 4)
+                    except (TypeError, ValueError):
+                        pass
+                if keep_max_val is not None:
+                    try:
+                        row[f"threshold_keep_max_{key}"] = round(float(keep_max_val), 4)
+                    except (TypeError, ValueError):
+                        pass
+                if drop_val is not None:
+                    try:
+                        row[f"threshold_drop_{key}"] = round(float(drop_val), 4)
+                    except (TypeError, ValueError):
+                        pass
             if quality_f is not None and ev_input_f is not None:
                 row[f"score_{key}"] = round(quality_f * ev_input_f, 6)
 

--- a/tests/test_daily_brief.py
+++ b/tests/test_daily_brief.py
@@ -1,0 +1,132 @@
+import importlib.util
+import math
+import os
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+from daily_.value_engine import LEAGUE_TIER_TOP
+
+_DAILY_BRIEF_PATH = Path(__file__).resolve().parent.parent / "daily_" / "daily_brief"
+if "numpy" not in sys.modules:
+    class _RandomStub:
+        @staticmethod
+        def seed(_seed):
+            return None
+
+        @staticmethod
+        def poisson(lam, size, *_, **__):
+            try:
+                count = int(size)
+            except (TypeError, ValueError):
+                count = 1
+            return [lam] * max(count, 1)
+
+    sys.modules["numpy"] = types.SimpleNamespace(random=_RandomStub())
+
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+
+    def _load_dotenv_stub(*_args, **_kwargs):
+        return None
+
+    dotenv_stub.load_dotenv = _load_dotenv_stub
+    sys.modules["dotenv"] = dotenv_stub
+
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+
+    class _SessionStub:
+        def __init__(self):
+            self.trust_env = False
+
+        def get(self, *_args, **_kwargs):
+            raise RuntimeError("requests Session stub used in tests")
+
+        def mount(self, *_args, **_kwargs):
+            return None
+
+    requests_stub.Session = _SessionStub
+    requests_stub.exceptions = types.SimpleNamespace(RequestException=Exception)
+    sys.modules["requests"] = requests_stub
+
+    adapters_stub = types.ModuleType("requests.adapters")
+
+    class _HTTPAdapterStub:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    adapters_stub.HTTPAdapter = _HTTPAdapterStub
+    sys.modules["requests.adapters"] = adapters_stub
+
+if "urllib3" not in sys.modules:
+    urllib3_stub = types.ModuleType("urllib3")
+    urllib3_util_stub = types.ModuleType("urllib3.util")
+    urllib3_retry_stub = types.ModuleType("urllib3.util.retry")
+
+    class _RetryStub:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    urllib3_retry_stub.Retry = _RetryStub
+    urllib3_util_stub.retry = urllib3_retry_stub
+    urllib3_stub.util = urllib3_util_stub
+    sys.modules["urllib3"] = urllib3_stub
+    sys.modules["urllib3.util"] = urllib3_util_stub
+    sys.modules["urllib3.util.retry"] = urllib3_retry_stub
+
+os.environ.setdefault("FOOTBALL_API_KEY", "dummy-key")
+_LOADER = SourceFileLoader("daily_brief_module", str(_DAILY_BRIEF_PATH))
+_SPEC = importlib.util.spec_from_loader(_LOADER.name, _LOADER)
+if _SPEC is None:  # pragma: no cover - defensive guard
+    raise ImportError(f"Unable to build spec for daily_brief module at {_DAILY_BRIEF_PATH}")
+_daily_brief_module = importlib.util.module_from_spec(_SPEC)
+_LOADER.exec_module(_daily_brief_module)
+apply_ev_filter = getattr(_daily_brief_module, "apply_ev_filter")
+
+
+def test_apply_ev_filter_populates_diagnostics_meta() -> None:
+    flag_map: dict[str, str] = {}
+    reason_map: dict[str, str] = {}
+    vi_map: dict[str, float | None] = {}
+    meta_map: dict[str, dict[str, object]] = {}
+
+    ev, kelly = apply_ev_filter(
+        key="ou_main_over",
+        ev=0.08,
+        kelly=0.07,
+        market="ou",
+        tier=LEAGUE_TIER_TOP,
+        min_bookmakers=10,
+        overround=1.08,
+        update_age=4.0,
+        flag_map=flag_map,
+        reason_map=reason_map,
+        vi_map=vi_map,
+        meta_map=meta_map,
+        odds=2.05,
+        model_prob=0.58,
+        consensus_prob=0.54,
+        data_quality=0.9,
+        sample_size=12,
+    )
+
+    assert ev is not None and kelly is not None
+    assert flag_map.get("ou_main_over") in {"keep", "review"}
+    assert "ou_main_over" not in reason_map
+    assert vi_map.get("ou_main_over") is not None
+
+    diagnostics = meta_map.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    entry = diagnostics.get("ou_main_over")
+    assert isinstance(entry, dict)
+    assert "quality" in entry and entry["quality"] is not None
+    assert "ev_input" in entry and entry["ev_input"] is not None
+    assert "ev_calibrated" in entry and entry["ev_calibrated"] is not None
+
+    thresholds = entry.get("thresholds")
+    assert isinstance(thresholds, dict)
+    assert math.isclose(float(thresholds["keep_min"]), 0.02, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["keep_max"]), 0.06, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["drop"]), 0.12, rel_tol=1e-9)

--- a/tests/test_value_engine.py
+++ b/tests/test_value_engine.py
@@ -18,6 +18,12 @@ def test_evaluate_rejects_insufficient_bookmakers() -> None:
     assert res["ev"] is None
     assert res["tag"] == "reject"
     assert "bookmakers" in res.get("reasons", ())
+    thresholds = res.get("thresholds")
+    assert isinstance(thresholds, dict)
+    assert math.isclose(float(thresholds["keep_min"]), 0.02, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["keep_max"]), 0.06, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["drop"]), 0.12, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["min_bookmakers"]), 6.0, rel_tol=1e-9)
 
 
 def test_consensus_shrinks_ev_for_top_tier() -> None:
@@ -37,6 +43,10 @@ def test_consensus_shrinks_ev_for_top_tier() -> None:
     assert math.isclose(res["ev_input"], 0.12, rel_tol=1e-9)
     assert res["ev"] < res["ev_input"]
     assert res["quality"] is not None and 0 < res["quality"] <= 1
+    thresholds = res.get("thresholds")
+    assert isinstance(thresholds, dict)
+    assert math.isclose(float(thresholds["consensus_alpha"]), 0.2, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["kelly_cap"]), 0.08, rel_tol=1e-9)
 
 
 def test_quality_penalty_reduces_ev() -> None:
@@ -58,3 +68,7 @@ def test_quality_penalty_reduces_ev() -> None:
     assert res["ev_calibrated"] is not None
     assert res["quality"] is not None and res["quality"] < 1.0
     assert res["ev"] < res["ev_calibrated"]
+    thresholds = res.get("thresholds")
+    assert isinstance(thresholds, dict)
+    assert math.isclose(float(thresholds["quality_reject"]), 0.3, rel_tol=1e-9)
+    assert math.isclose(float(thresholds["quality_review"]), 0.6, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- return market threshold metadata from `evaluate_ev_market` and surface it through `apply_ev_filter` diagnostics
- adapt the daily brief generator to keep diagnostic metadata under `meta_map['diagnostics']` and expose EV thresholds in exported rows
- extend EV filtering tests and add a daily brief unit test that exercises the diagnostics payload

## Testing
- pytest tests/test_value_engine.py tests/test_daily_brief.py tests/test_football_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cd259cbcbc833082d12e60b5334f05